### PR TITLE
Implement API features and persistence

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -22,7 +22,7 @@ paths:
         '401': { description: Unauthorized }
   /classify:
     post:
-      summary: Classify text (stub)
+      summary: Classify text
       security: [{ ApiKeyAuth: [] }]
       requestBody:
         required: true
@@ -31,16 +31,70 @@ paths:
             schema: { type: object, properties: { text: { type: string } }, required: [text] }
       responses:
         '200':
-          description: Stubbed response
+          description: Classification result
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   ok: { type: boolean }
-                  label: { type: string }
-                  score: { type: number }
+                  label: { type: string, enum: [positive, negative, neutral] }
+                  score: { type: number, minimum: 0, maximum: 1 }
                 required: [ok, label, score]
+        '400': { description: Invalid payload }
+        '401': { description: Unauthorized }
+  /mandalas:
+    post:
+      summary: Upload a mandala PNG
+      security: [{ ApiKeyAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          image/png:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '201':
+          description: Mandala stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok: { type: boolean }
+                  id: { type: string }
+                  key: { type: string }
+                  size: { type: integer }
+                required: [ok, id, key, size]
+        '401': { description: Unauthorized }
+        '413': { description: Payload too large }
+  /mandalas/{key}:
+    get:
+      summary: Retrieve a mandala PNG
+      parameters:
+        - name: key
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: PNG bytes
+          content:
+            image/png:
+              schema: { type: string, format: binary }
+        '404': { description: Not found }
+  /webhooks/stripe:
+    post:
+      summary: Stripe webhook endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { type: object }
+      responses:
+        '200': { description: Acknowledged }
+        '400': { description: Invalid signature or payload }
 components:
   securitySchemes:
     ApiKeyAuth:

--- a/src/lib/classifier.ts
+++ b/src/lib/classifier.ts
@@ -1,0 +1,60 @@
+const positive = new Set([
+  "calm",
+  "centered",
+  "clear",
+  "focused",
+  "peace",
+  "peaceful",
+  "relaxed",
+  "serene",
+  "steady",
+  "victory",
+]);
+
+const negative = new Set([
+  "angry",
+  "anxious",
+  "chaos",
+  "confused",
+  "fear",
+  "frantic",
+  "panic",
+  "rage",
+  "stress",
+  "tired",
+]);
+
+export type Classification = {
+  label: "positive" | "negative" | "neutral";
+  score: number;
+};
+
+export function classifyText(text: string): Classification {
+  const normalized = text.toLowerCase();
+  const tokens = normalized.match(/[a-z']+/g) ?? [];
+
+  let pos = 0;
+  let neg = 0;
+  for (const token of tokens) {
+    if (positive.has(token)) {
+      pos += 1;
+    } else if (negative.has(token)) {
+      neg += 1;
+    }
+  }
+
+  const total = pos + neg;
+  if (total === 0) {
+    return { label: "neutral", score: 0.5 };
+  }
+
+  if (pos > neg) {
+    return { label: "positive", score: Math.min(1, pos / total) };
+  }
+
+  if (neg > pos) {
+    return { label: "negative", score: Math.min(1, neg / total) };
+  }
+
+  return { label: "neutral", score: 0.5 };
+}

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,34 @@
+const encoder = new TextEncoder();
+
+function toHex(buffer: ArrayBuffer): string {
+  const view = new Uint8Array(buffer);
+  return Array.from(view, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
+  return toHex(digest);
+}
+
+export async function hmacSha256Hex(secret: string, value: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(value));
+  return toHex(signature);
+}
+
+export function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,9 +1,45 @@
-export type LogEntry = {
-  id: string; ts: number; route: string; status: number; ms: number;
-  ip?: string; ua?: string; apiKeyId?: string; err?: string;
+import { sha256Hex } from "./hash";
+
+type LogEnv = {
+  DB: D1Database;
 };
 
-// TODO: bind env.DB_LOGS (D1) later
-export async function logRequest(/* env: Env, */ _entry: LogEntry) {
-  // no-op stub; wire to D1 after migration lands
+export type LogEntry = {
+  id: string;
+  ts: number;
+  route: string;
+  status: number;
+  ms: number;
+  ip?: string;
+  ua?: string;
+  apiKeyId?: string;
+  err?: string;
+};
+
+export async function logRequest(env: LogEnv, entry: LogEntry): Promise<void> {
+  if (!env?.DB) {
+    return;
+  }
+
+  const [ipSha, uaSha] = await Promise.all([
+    entry.ip ? sha256Hex(entry.ip) : Promise.resolve(undefined),
+    entry.ua ? sha256Hex(entry.ua) : Promise.resolve(undefined),
+  ]);
+
+  await env.DB.prepare(
+    `INSERT INTO requests (id, ts, route, status, ms, ip_sha256, ua_sha256, api_key_id, err)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      entry.id,
+      entry.ts,
+      entry.route,
+      entry.status,
+      entry.ms,
+      ipSha ?? null,
+      uaSha ?? null,
+      entry.apiKeyId ?? null,
+      entry.err ?? null
+    )
+    .run();
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,46 @@
+export {};
+
+declare global {
+  interface D1Result<T = unknown> {
+    results?: T[];
+  }
+
+  interface D1PreparedStatement {
+    bind(...values: unknown[]): D1PreparedStatement;
+    first<T = unknown>(): Promise<T | null>;
+    all<T = unknown>(): Promise<D1Result<T>>;
+    run<T = unknown>(): Promise<T>;
+  }
+
+  interface D1Database {
+    prepare(query: string): D1PreparedStatement;
+  }
+
+  interface R2HTTPMetadata {
+    contentType?: string;
+  }
+
+  interface R2Object {
+    body: ReadableStream | null;
+    size: number;
+    httpMetadata?: R2HTTPMetadata;
+  }
+
+  interface R2PutOptions {
+    httpMetadata?: R2HTTPMetadata;
+  }
+
+  interface R2Bucket {
+    put(
+      key: string,
+      value: ReadableStream | ArrayBuffer | ArrayBufferView | string,
+      options?: R2PutOptions
+    ): Promise<void>;
+    get(key: string): Promise<R2Object | null>;
+  }
+
+  interface ExecutionContext {
+    waitUntil(promise: Promise<unknown>): void;
+    passThroughOnException(): void;
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,46 +1,232 @@
+import { classifyText } from "./lib/classifier";
+import { hmacSha256Hex, timingSafeEqualHex } from "./lib/hash";
+import { logRequest } from "./lib/log";
+import { recordPayment } from "./lib/payments";
+import { hit } from "./lib/rateLimit";
+
 export interface Env {
   API_KEY: string;
-  // DB_LOGS: D1Database;             // bind later
-  // MANDALA_BUCKET: R2Bucket;        // bind later
-  // STRIPE_WEBHOOK_SECRET: string;   // env later
+  DB: D1Database;
+  MANDALA_BUCKET: R2Bucket;
+  STRIPE_WEBHOOK_SECRET: string;
+}
+
+const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
+
+function getClientIp(request: Request): string | undefined {
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    request.headers.get("x-real-ip") ??
+    undefined
+  );
+}
+
+async function handleClassify(request: Request): Promise<Response> {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch (err) {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const text = typeof (payload as { text?: unknown }).text === "string" ? (payload as { text: string }).text.trim() : "";
+  if (!text) {
+    return new Response("Missing text", { status: 400 });
+  }
+
+  const result = classifyText(text);
+  return new Response(JSON.stringify({ ok: true, ...result }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function handleMandalaUpload(request: Request, env: Env): Promise<Response> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("image/png")) {
+    return new Response("PNG required", { status: 415 });
+  }
+
+  const buffer = await request.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    return new Response("Empty payload", { status: 400 });
+  }
+  if (buffer.byteLength > MAX_UPLOAD_BYTES) {
+    return new Response("Payload too large", { status: 413 });
+  }
+
+  const id = crypto.randomUUID();
+  const key = `${id}.png`;
+  await env.MANDALA_BUCKET.put(key, buffer, {
+    httpMetadata: { contentType: "image/png" },
+  });
+
+  const metadata = { size: buffer.byteLength };
+  await env.DB.prepare(`INSERT INTO mandalas (id, ts, r2_key, meta_json) VALUES (?, ?, ?, ?)`)
+    .bind(id, Date.now(), key, JSON.stringify(metadata))
+    .run();
+
+  return new Response(JSON.stringify({ ok: true, id, key, size: buffer.byteLength }), {
+    status: 201,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function handleMandalaDownload(key: string, env: Env): Promise<Response> {
+  if (!key) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const object = await env.MANDALA_BUCKET.get(key);
+  if (!object || !object.body) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  return new Response(object.body, {
+    status: 200,
+    headers: { "content-type": object.httpMetadata?.contentType ?? "image/png" },
+  });
+}
+
+function parseStripeSignature(header: string | null): { timestamp: string; signature: string } | null {
+  if (!header) return null;
+  const parts = header.split(",");
+  const map = new Map<string, string>();
+  for (const part of parts) {
+    const [key, value] = part.split("=");
+    if (key && value) {
+      map.set(key.trim(), value.trim());
+    }
+  }
+  const timestamp = map.get("t");
+  const signature = map.get("v1");
+  if (!timestamp || !signature) {
+    return null;
+  }
+  return { timestamp, signature };
+}
+
+async function handleStripeWebhook(request: Request, env: Env): Promise<Response> {
+  const parsed = parseStripeSignature(request.headers.get("stripe-signature"));
+  if (!parsed) {
+    return new Response("Missing signature", { status: 400 });
+  }
+
+  const rawBody = await request.text();
+  const payload = `${parsed.timestamp}.${rawBody}`;
+  const expected = await hmacSha256Hex(env.STRIPE_WEBHOOK_SECRET, payload);
+  if (!timingSafeEqualHex(parsed.signature, expected)) {
+    return new Response("Invalid signature", { status: 400 });
+  }
+
+  let event: any;
+  try {
+    event = JSON.parse(rawBody);
+  } catch (err) {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const type: string = event?.type ?? "";
+  const dataObject = event?.data?.object ?? {};
+  const id: string = dataObject.id ?? event?.id ?? crypto.randomUUID();
+  const createdRaw: number = Number(dataObject.created ?? event?.created ?? Date.now());
+  const createdMs = createdRaw > 1_000_000_000_000 ? createdRaw : createdRaw * 1000;
+  const amount: number = Number(
+    dataObject.amount_total ?? dataObject.amount_received ?? dataObject.amount ?? 0
+  );
+  const email: string | null =
+    dataObject.customer_details?.email ??
+    dataObject.customer_email ??
+    dataObject.receipt_email ??
+    dataObject.charges?.data?.[0]?.billing_details?.email ??
+    null;
+
+  if (type && amount > 0) {
+    await recordPayment(env, {
+      id,
+      ts: createdMs,
+      amount,
+      email,
+    });
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const start = Date.now();
     const url = new URL(request.url);
+    const method = request.method.toUpperCase();
+    const route = `${method} ${url.pathname}`;
+    const ip = getClientIp(request);
+    const ua = request.headers.get("user-agent") ?? undefined;
+    let response: Response;
+    let errorMessage: string | undefined;
+    let apiKeyForLog: string | undefined;
 
-    // 1) Public health
-    if (url.pathname === "/healthz" && request.method === "GET") {
-      return new Response(JSON.stringify({ status: "ok" }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
+    try {
+      if (method === "GET" && url.pathname === "/healthz") {
+        response = new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      } else if (url.pathname === "/favicon.ico") {
+        response = new Response(null, {
+          status: 204,
+          headers: { "cache-control": "public, max-age=86400" },
+        });
+      } else if (method === "GET" && url.pathname.startsWith("/mandalas/")) {
+        const key = decodeURIComponent(url.pathname.replace("/mandalas/", ""));
+        response = await handleMandalaDownload(key, env);
+      } else if (method === "POST" && url.pathname === "/webhooks/stripe") {
+        response = await handleStripeWebhook(request, env);
+      } else {
+        const key = request.headers.get("x-api-key");
+        apiKeyForLog = key ?? undefined;
+        if (!key || key !== env.API_KEY) {
+          response = new Response("Unauthorized", { status: 401 });
+        } else {
+          const allowed = hit(ip ?? "unknown");
+          if (!allowed) {
+            response = new Response("Too Many Requests", {
+              status: 429,
+              headers: { "retry-after": "60" },
+            });
+          } else if (method === "POST" && url.pathname === "/classify") {
+            response = await handleClassify(request);
+          } else if (method === "POST" && url.pathname === "/mandalas") {
+            response = await handleMandalaUpload(request, env);
+          } else {
+            response = new Response("Not found", { status: 404 });
+          }
+        }
+      }
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : String(err);
+      response = new Response("Internal Error", { status: 500 });
     }
 
-    // 2) Favicon bypass (unauth)
-    if (url.pathname === "/favicon.ico") {
-        return new Response(null, { status: 204, headers: { 'cache-control': 'public, max-age=86400' }});
-    }
+    const duration = Date.now() - start;
+    const logId = crypto.randomUUID();
+    ctx.waitUntil(
+      logRequest(env, {
+        id: logId,
+        ts: Date.now(),
+        route,
+        status: response.status,
+        ms: duration,
+        ip,
+        ua,
+        apiKeyId: apiKeyForLog ? apiKeyForLog.slice(-8) : undefined,
+        err: errorMessage,
+      })
+    );
 
-    // 3) Auth gate for everything else
-    const key = request.headers.get("x-api-key");
-    if (!key || key !== env.API_KEY) {
-      return new Response("Unauthorized", { status: 401 });
-    }
-
-    // 4) TODO Issue 2: POST /classify (stub)
-    if (url.pathname === "/classify" && request.method === "POST") {
-      return new Response(
-        JSON.stringify({ ok: true, label: "neutral", score: 0.5 }),
-        { status: 200, headers: { "content-type": "application/json" } }
-      );
-    }
-
-    // 5) TODO Issue 4: R2 /mandalas endpoints
-    // - POST /mandalas (auth)
-    // - GET  /mandalas/:key (public)
-
-    // default
-    return new Response("Not found", { status: 404 });
+    return response;
   },
 };

--- a/tests/billing_webhook.test.ts
+++ b/tests/billing_webhook.test.ts
@@ -1,4 +1,66 @@
-describe.skip("Stripe webhook", () => {
-  test("valid signature -> 200 and row written", async () => {});
-  test("invalid signature -> 400", async () => {});
+import worker from "../src/worker";
+import { createExecutionContext, createTestEnv } from "./helpers";
+import { hmacSha256Hex } from "../src/lib/hash";
+
+describe("Stripe webhook", () => {
+  test("valid signature -> 200 and row written", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+
+    const payload = {
+      id: "evt_1",
+      type: "checkout.session.completed",
+      data: {
+        object: {
+          id: "cs_test",
+          created: 1700000000,
+          amount_total: 4200,
+          customer_details: { email: "user@example.com" },
+        },
+      },
+    };
+    const rawBody = JSON.stringify(payload);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = await hmacSha256Hex(env.STRIPE_WEBHOOK_SECRET, `${timestamp}.${rawBody}`);
+    const res = await worker.fetch(
+      new Request("https://defrag.example/webhooks/stripe", {
+        method: "POST",
+        headers: {
+          "stripe-signature": `t=${timestamp},v1=${signature}`,
+          "cf-connecting-ip": "192.0.2.10",
+        },
+        body: rawBody,
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+
+    expect(res.status).toBe(200);
+    expect(env.DB.tables.payments).toHaveLength(1);
+    const payment = env.DB.tables.payments[0];
+    expect(payment.id).toBe("cs_test");
+    expect(payment.amount).toBe(4200);
+    expect(typeof payment.email_hash).toBe("string");
+  });
+
+  test("invalid signature -> 400", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("https://defrag.example/webhooks/stripe", {
+        method: "POST",
+        headers: {
+          "stripe-signature": "t=1,v1=badsig",
+          "cf-connecting-ip": "192.0.2.11",
+        },
+        body: JSON.stringify({}),
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+    expect(res.status).toBe(400);
+    expect(env.DB.tables.payments).toHaveLength(0);
+  });
 });

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1,5 +1,68 @@
-describe.skip("POST /classify", () => {
-  test("401 without key", async () => {});
-  test("400 on invalid body", async () => {});
-  test("200 on valid request returns stubbed JSON", async () => {});
+import worker from "../src/worker";
+import { createExecutionContext, createTestEnv } from "./helpers";
+
+describe("POST /classify", () => {
+  test("401 without key", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("https://defrag.example/classify", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "cf-connecting-ip": "203.0.113.1",
+        },
+        body: JSON.stringify({ text: "calm and focused" }),
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+    expect(res.status).toBe(401);
+  });
+
+  test("400 on invalid body", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("https://defrag.example/classify", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": env.API_KEY,
+          "cf-connecting-ip": "203.0.113.2",
+        },
+        body: JSON.stringify({ text: "" }),
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+    expect(res.status).toBe(400);
+  });
+
+  test("200 on valid request returns classification", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("https://defrag.example/classify", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": env.API_KEY,
+          "cf-connecting-ip": "203.0.113.3",
+        },
+        body: JSON.stringify({ text: "I feel calm and serene today" }),
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.label).toBe("positive");
+    expect(body.score).toBeGreaterThan(0);
+  });
 });

--- a/tests/db_requests.test.ts
+++ b/tests/db_requests.test.ts
@@ -1,3 +1,34 @@
-describe.skip("D1 requests logging", () => {
-  test("writes and reads a row", async () => {});
+import { sha256Hex } from "../src/lib/hash";
+import { logRequest } from "../src/lib/log";
+import { createTestEnv, D1DatabaseStub } from "./helpers";
+
+describe("D1 requests logging", () => {
+  test("writes and reads a row", async () => {
+    const db = new D1DatabaseStub();
+    const env = createTestEnv({ DB: db });
+    const entry = {
+      id: "req-1",
+      ts: 1700000000000,
+      route: "POST /classify",
+      status: 200,
+      ms: 42,
+      ip: "1.2.3.4",
+      ua: "jest",
+      apiKeyId: "12345678",
+    } as const;
+
+    await logRequest(env, entry);
+
+    expect(db.tables.requests).toHaveLength(1);
+    const row = db.tables.requests[0];
+    expect(row).toMatchObject({
+      id: entry.id,
+      route: entry.route,
+      status: entry.status,
+      ms: entry.ms,
+      api_key_id: entry.apiKeyId,
+    });
+    expect(row.ip_sha256).toBe(await sha256Hex(entry.ip));
+    expect(row.ua_sha256).toBe(await sha256Hex(entry.ua));
+  });
 });

--- a/tests/favicon.test.ts
+++ b/tests/favicon.test.ts
@@ -1,19 +1,18 @@
-import { unstable_dev } from "wrangler";
-import type { Unstable_DevWorker } from "wrangler";
-
-let worker: Unstable_DevWorker;
-
-beforeAll(async () => {
-  worker = await unstable_dev("src/worker.ts", { experimental: { disableExperimentalWarning: true }});
-});
-
-afterAll(async () => {
-  await worker.stop();
-});
+import worker from "../src/worker";
+import { createExecutionContext, createTestEnv } from "./helpers";
 
 describe("favicon bypass", () => {
   test("GET /favicon.ico returns 204 and no auth required", async () => {
-    const res = await worker.fetch("/favicon.ico");
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("https://defrag.example/favicon.ico", {
+        headers: { "cf-connecting-ip": "198.51.100.3" },
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
     expect(res.status).toBe(204);
   });
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,191 @@
+import type { Env } from "../src/worker";
+
+export class D1PreparedStatementStub {
+  private params: unknown[] = [];
+
+  constructor(private readonly db: D1DatabaseStub, private readonly sql: string) {}
+
+  bind(...params: unknown[]): D1PreparedStatementStub {
+    this.params = params;
+    return this;
+  }
+
+  async run(): Promise<void> {
+    this.db.execute(this.sql, this.params);
+  }
+
+  async first<T>(): Promise<T | null> {
+    const all = await this.all<T>();
+    return all.results[0] ?? null;
+  }
+
+  async all<T>(): Promise<{ results: T[] }> {
+    return { results: this.db.query<T>(this.sql, this.params) };
+  }
+}
+
+export class D1DatabaseStub {
+  tables: Record<string, any[]> = {
+    requests: [],
+    mandalas: [],
+    payments: [],
+  };
+
+  prepare(sql: string): D1PreparedStatementStub {
+    return new D1PreparedStatementStub(this, sql);
+  }
+
+  execute(sql: string, params: unknown[]): void {
+    const normalized = sql.trim().toLowerCase();
+    if (normalized.startsWith("insert into requests")) {
+      const [id, ts, route, status, ms, ipSha, uaSha, apiKeyId, err] = params;
+      this.tables.requests.push({
+        id,
+        ts,
+        route,
+        status,
+        ms,
+        ip_sha256: ipSha,
+        ua_sha256: uaSha,
+        api_key_id: apiKeyId,
+        err,
+      });
+      return;
+    }
+
+    if (normalized.startsWith("insert into mandalas")) {
+      const [id, ts, key, meta] = params;
+      this.tables.mandalas.push({ id, ts, r2_key: key, meta_json: meta });
+      return;
+    }
+
+    if (normalized.startsWith("insert or ignore into payments")) {
+      const [id, ts, amount, emailHash] = params;
+      const exists = this.tables.payments.some((row) => row.id === id);
+      if (!exists) {
+        this.tables.payments.push({ id, ts, amount, email_hash: emailHash });
+      }
+      return;
+    }
+
+    throw new Error(`Unsupported SQL: ${sql}`);
+  }
+
+  query<T>(sql: string, params: unknown[]): T[] {
+    const normalized = sql.trim().toLowerCase();
+    if (normalized.startsWith("select * from requests")) {
+      if (params.length === 0) {
+        return this.tables.requests as T[];
+      }
+      const [id] = params;
+      return this.tables.requests.filter((row) => row.id === id) as T[];
+    }
+
+    throw new Error(`Unsupported query: ${sql}`);
+  }
+}
+
+type StoredObject = {
+  value: Uint8Array;
+  httpMetadata?: { contentType?: string };
+};
+
+export class R2BucketStub {
+  private readonly store = new Map<string, StoredObject>();
+
+  async put(
+    key: string,
+    value: ReadableStream | ArrayBuffer | ArrayBufferView | string,
+    options?: { httpMetadata?: { contentType?: string } }
+  ): Promise<void> {
+    const body = await readBody(value);
+    this.store.set(key, { value: body, httpMetadata: options?.httpMetadata });
+  }
+
+  async get(key: string): Promise<R2Object | null> {
+    const stored = this.store.get(key);
+    if (!stored) {
+      return null;
+    }
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(stored.value);
+        controller.close();
+      },
+    });
+
+    return {
+      body: stream,
+      size: stored.value.byteLength,
+      httpMetadata: stored.httpMetadata,
+    } as R2Object;
+  }
+
+  has(key: string): boolean {
+    return this.store.has(key);
+  }
+}
+
+async function readBody(
+  value: ReadableStream | ArrayBuffer | ArrayBufferView | string
+): Promise<Uint8Array> {
+  if (typeof value === "string") {
+    return new TextEncoder().encode(value);
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value);
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer.slice(value.byteOffset, value.byteOffset + value.byteLength));
+  }
+
+  if (value instanceof ReadableStream) {
+    const reader = value.getReader();
+    const chunks: Uint8Array[] = [];
+    while (true) {
+      const { value: chunk, done } = await reader.read();
+      if (done) break;
+      chunks.push(chunk);
+    }
+    const size = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+    const result = new Uint8Array(size);
+    let offset = 0;
+    for (const chunk of chunks) {
+      result.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return result;
+  }
+
+  throw new Error("Unsupported body type");
+}
+
+export function createTestEnv(overrides: Partial<Env & { DB: D1DatabaseStub; MANDALA_BUCKET: R2BucketStub }> = {}) {
+  const db = overrides.DB ?? new D1DatabaseStub();
+  const bucket = overrides.MANDALA_BUCKET ?? new R2BucketStub();
+  return {
+    API_KEY: "test-key",
+    STRIPE_WEBHOOK_SECRET: "whsec_test",
+    DB: db,
+    MANDALA_BUCKET: bucket,
+    ...overrides,
+  } satisfies Env & { DB: D1DatabaseStub; MANDALA_BUCKET: R2BucketStub };
+}
+
+export function createExecutionContext() {
+  const promises: Promise<unknown>[] = [];
+  return {
+    waitUntil(promise: Promise<unknown>) {
+      promises.push(promise);
+    },
+    passThroughOnException() {
+      // no-op for tests
+    },
+    async waitForAll() {
+      await Promise.all(promises);
+    },
+  };
+}

--- a/tests/mandalas.test.ts
+++ b/tests/mandalas.test.ts
@@ -1,4 +1,70 @@
-describe.skip("R2 /mandalas", () => {
-  test("POST requires auth and stores PNG", async () => {});
-  test("GET returns content with correct type", async () => {});
+import worker from "../src/worker";
+import { createExecutionContext, createTestEnv } from "./helpers";
+
+describe("R2 /mandalas", () => {
+  test("POST requires auth and stores PNG", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+
+    const unauthorized = await worker.fetch(
+      new Request("https://defrag.example/mandalas", {
+        method: "POST",
+        headers: {
+          "content-type": "image/png",
+          "cf-connecting-ip": "198.51.100.10",
+        },
+        body: new Uint8Array([137, 80, 78, 71]),
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    expect(unauthorized.status).toBe(401);
+
+    const pngBytes = new Uint8Array([137, 80, 78, 71, 0, 0, 0, 0]);
+    const res = await worker.fetch(
+      new Request("https://defrag.example/mandalas", {
+        method: "POST",
+        headers: {
+          "content-type": "image/png",
+          "x-api-key": env.API_KEY,
+          "cf-connecting-ip": "198.51.100.11",
+        },
+        body: pngBytes,
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.key).toMatch(/\.png$/);
+    expect(env.DB.tables.mandalas).toHaveLength(1);
+    expect(env.MANDALA_BUCKET.has(body.key)).toBe(true);
+  });
+
+  test("GET returns content with correct type", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+
+    const key = "test.png";
+    await env.MANDALA_BUCKET.put(key, new Uint8Array([1, 2, 3, 4]), {
+      httpMetadata: { contentType: "image/png" },
+    });
+
+    const res = await worker.fetch(
+      new Request(`https://defrag.example/mandalas/${key}`, {
+        headers: { "cf-connecting-ip": "198.51.100.12" },
+      }),
+      env,
+      ctx as unknown as ExecutionContext
+    );
+    await ctx.waitForAll();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    expect(Array.from(bytes)).toEqual([1, 2, 3, 4]);
+  });
 });

--- a/tests/rate_limit.test.ts
+++ b/tests/rate_limit.test.ts
@@ -1,3 +1,29 @@
-describe.skip("rate limit", () => {
-  test("exceed threshold -> 429", async () => {});
+import worker from "../src/worker";
+import { createExecutionContext, createTestEnv } from "./helpers";
+
+describe("rate limit", () => {
+  test("exceed threshold -> 429", async () => {
+    const env = createTestEnv();
+    const ctx = createExecutionContext();
+
+    const requestFactory = () =>
+      new Request("https://defrag.example/classify", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": env.API_KEY,
+          "cf-connecting-ip": "203.0.113.99",
+        },
+        body: JSON.stringify({ text: "neutral" }),
+      });
+
+    let lastResponse: Response | null = null;
+    for (let i = 0; i < 61; i += 1) {
+      lastResponse = await worker.fetch(requestFactory(), env, ctx as unknown as ExecutionContext);
+    }
+    await ctx.waitForAll();
+
+    expect(lastResponse).not.toBeNull();
+    expect(lastResponse!.status).toBe(429);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM"],
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- wire the worker to log requests, enforce rate limits, classify text, handle Stripe webhooks, and stream R2 mandala assets
- add hashing utilities plus classifier logic, D1 persistence helpers, and comprehensive Jest coverage with test doubles
- document the updated API surface including classification, mandala storage, and billing webhook endpoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68f2fce28ca48331a7f699e25a51166f